### PR TITLE
Added syntax highlighting in Twig control blocks

### DIFF
--- a/grammars/html (twig).cson
+++ b/grammars/html (twig).cson
@@ -370,6 +370,60 @@
         'include': '#twig-hashes'
       }
     ]
+  'twig-expression-tags':
+    'begin': '\\{\\%-?'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.tag.twig'
+    'end': '-?\\%\\}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.tag.twig'
+    'name': 'meta.tag.template.value.twig'
+    'patterns': [
+      {
+        'include': '#twig-constants'
+      }
+      {
+        'include': '#twig-operators'
+      }
+      {
+        'include': '#twig-functions-warg'
+      }
+      {
+        'include': '#twig-functions'
+      }
+      {
+        'include': '#twig-macros'
+      }
+      {
+        'include': '#twig-objects'
+      }
+      {
+        'include': '#twig-properties'
+      }
+      {
+        'include': '#twig-filters-warg'
+      }
+      {
+        'include': '#twig-filters'
+      }
+      {
+        'include': '#twig-filters-warg-ud'
+      }
+      {
+        'include': '#twig-filters-ud'
+      }
+      {
+        'include': '#twig-strings'
+      }
+      {
+        'include': '#twig-arrays'
+      }
+      {
+        'include': '#twig-hashes'
+      }
+    ]
   'twig-comment-tags':
     'begin': '\\{#-?'
     'beginCaptures':


### PR DESCRIPTION
(fixes #1 - kind of a hacky fix but better than nothing)
